### PR TITLE
Adds support for changes in $PSNativeCommandArgumentPassing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: publish
 
 on:
   push:
+    branches: 
+      - main
     paths:
       - powershell-az.psd1
 

--- a/powershell-az.psd1
+++ b/powershell-az.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '0.1.5'
+    ModuleVersion = '0.1.6'
     RootModule = 'powershell-az.psm1'
     GUID = 'efe1acda-f1e4-4b28-80b3-6417a87fd9d6'
     Author = 'https://github.com/smokedlinq'

--- a/powershell-az.psm1
+++ b/powershell-az.psm1
@@ -182,7 +182,11 @@ function ConvertTo-AzJson {
     }
 
     end {
-        ($Items | ConvertTo-Json -AsArray:$AsArray -Compress -Depth $Depth | ConvertTo-Json) -replace '^"|"$'
+        if ($PSNativeCommandArgumentPassing -in ('Legacy', 'Windows', '', $null)) {
+            ($Items | ConvertTo-Json -AsArray:$AsArray -Compress -Depth $Depth | ConvertTo-Json) -replace '^"|"$'
+        } else {
+            ($Items | ConvertTo-Json -AsArray:$AsArray -Compress -Depth $Depth)
+        }
     }
 }
 

--- a/powershell-az.psm1
+++ b/powershell-az.psm1
@@ -182,10 +182,10 @@ function ConvertTo-AzJson {
     }
 
     end {
-        if ($PSNativeCommandArgumentPassing -in ('Legacy', 'Windows', '', $null)) {
-            ($Items | ConvertTo-Json -AsArray:$AsArray -Compress -Depth $Depth | ConvertTo-Json) -replace '^"|"$'
-        } else {
+        if ($PSNativeCommandArgumentPassing -eq 'Standard') {
             ($Items | ConvertTo-Json -AsArray:$AsArray -Compress -Depth $Depth)
+        } else {
+            ($Items | ConvertTo-Json -AsArray:$AsArray -Compress -Depth $Depth | ConvertTo-Json) -replace '^"|"$'
         }
     }
 }

--- a/powershell-az.tests.ps1
+++ b/powershell-az.tests.ps1
@@ -97,8 +97,10 @@ Describe 'powershell-az.psm1' {
         }
 
         It 'with $PSNativeCommandArgumentPassing = Standard should encode JSON as string' {
+            $_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
             $PSNativeCommandArgumentPassing = 'Standard'
             $Value = @{property='value'} | ConvertTo-AzJson
+            $PSNativeCommandArgumentPassing = $_PSNativeCommandArgumentPassing
             $Value | Should -Be '{"property":"value"}'
         }
 

--- a/powershell-az.tests.ps1
+++ b/powershell-az.tests.ps1
@@ -97,14 +97,13 @@ Describe 'powershell-az.psm1' {
         }
 
         It 'with $PSNativeCommandArgumentPassing = Standard should encode JSON as string' {
-            $_PSNativeCommandArgumentPassing = $PSNativeCommandArgumentPassing
             $PSNativeCommandArgumentPassing = 'Standard'
             $Value = @{property='value'} | ConvertTo-AzJson
-            $PSNativeCommandArgumentPassing = $_PSNativeCommandArgumentPassing
             $Value | Should -Be '{"property":"value"}'
         }
 
         It 'with $PSNativeCommandArgumentPassing != Standard should encode JSON as string without quotes' {
+            $PSNativeCommandArgumentPassing = 'Legacy'
             $Value = @{property='value'} | ConvertTo-AzJson
             $Value | Should -Be '{\"property\":\"value\"}'
         }

--- a/powershell-az.tests.ps1
+++ b/powershell-az.tests.ps1
@@ -97,13 +97,13 @@ Describe 'powershell-az.psm1' {
         }
 
         It 'with $PSNativeCommandArgumentPassing = Standard should encode JSON as string' {
-            $PSNativeCommandArgumentPassing = 'Standard'
+            $global:PSNativeCommandArgumentPassing = 'Standard'
             $Value = @{property='value'} | ConvertTo-AzJson
             $Value | Should -Be '{"property":"value"}'
         }
 
         It 'with $PSNativeCommandArgumentPassing != Standard should encode JSON as string without quotes' {
-            $PSNativeCommandArgumentPassing = 'Legacy'
+            $global:PSNativeCommandArgumentPassing = 'Legacy'
             $Value = @{property='value'} | ConvertTo-AzJson
             $Value | Should -Be '{\"property\":\"value\"}'
         }

--- a/powershell-az.tests.ps1
+++ b/powershell-az.tests.ps1
@@ -92,8 +92,19 @@ Describe 'powershell-az.psm1' {
 
     Context 'ConvertTo-AzJson' {
         It 'should encode JSON as string without quotes' {
-            $Value = @{} | ConvertTo-Json
+            $Value = @{} | ConvertTo-AzJson
             $Value | Should -Be '{}'
+        }
+
+        It 'with $PSNativeCommandArgumentPassing = Standard should encode JSON as string' {
+            $PSNativeCommandArgumentPassing = 'Standard'
+            $Value = @{property='value'} | ConvertTo-AzJson
+            $Value | Should -Be '{"property":"value"}'
+        }
+
+        It 'with $PSNativeCommandArgumentPassing != Standard should encode JSON as string without quotes' {
+            $Value = @{property='value'} | ConvertTo-AzJson
+            $Value | Should -Be '{\"property\":\"value\"}'
         }
     }
 


### PR DESCRIPTION
If the mode is `Standard` then the double encoding of the parameter is not performed as PowerShell now sends the value correctly to the process. Otherwise use the double converted JSON string.